### PR TITLE
feat(products): agregando el endpoint productos, CRUD y query

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import express, { Application, Express, Request, Response } from 'express';
 import dotenv from 'dotenv';
 
 import healthyRoute from '@/routes/healthyRoute';
+import productRoute from '@/routes/productRoute';
 
 dotenv.config();
 
@@ -12,6 +13,7 @@ const port = process.env.PORT || 5000;
 
 app.use(express.json());
 app.use('/healthy', healthyRoute);
+app.use('/products', productRoute);
 
 app.get('/', (req: Request, res: Response) => {
   res.send('Hello World!');

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -1,0 +1,452 @@
+[
+  {
+    "id": "1",
+    "name": "Toilet Paper",
+    "brand": "Charmin",
+    "stock": "1632",
+    "batch": "2020-0001",
+    "expiration": "2023-06-30",
+    "discount": "0"
+  },
+  {
+    "id": "2",
+    "name": "Hand Sanitizer",
+    "brand": "Purell",
+    "stock": "438",
+    "batch": "2021-0002",
+    "expiration": "2024-09-15",
+    "discount": "10"
+  },
+  {
+    "id": "3",
+    "name": "Laundry Detergent",
+    "brand": "Tide",
+    "stock": "789",
+    "batch": "2021-0003",
+    "expiration": "2025-12-31",
+    "discount": "20"
+  },
+  {
+    "id": "4",
+    "name": "Canned Soup",
+    "brand": "Campbell's",
+    "stock": "1200",
+    "batch": "2020-0004",
+    "expiration": "2022-11-30",
+    "discount": "0"
+  },
+  {
+    "name": "Breakfast Cereal",
+    "brand": "Kellogg's",
+    "stock": "1050",
+    "batch": "2021-0005",
+    "expiration": "2023-10-31",
+    "discount": "15",
+    "id": "5"
+  },
+  {
+    "name": "Pasta",
+    "brand": "Barilla",
+    "stock": "950",
+    "batch": "2020-0006",
+    "expiration": "2024-08-31",
+    "discount": "0",
+    "id": "6"
+  },
+  {
+    "name": "Frozen Pizza",
+    "brand": "DiGiorno",
+    "stock": "650",
+    "batch": "2021-0007",
+    "expiration": "2023-07-31",
+    "discount": "10",
+    "id": "7"
+  },
+  {
+    "name": "Paper Towels",
+    "brand": "Bounty",
+    "stock": "875",
+    "batch": "2020-0008",
+    "expiration": "2022-09-30",
+    "discount": "0",
+    "id": "8"
+  },
+  {
+    "name": "Canned Tuna",
+    "brand": "StarKist",
+    "stock": "1100",
+    "batch": "2021-0009",
+    "expiration": "2024-05-31",
+    "discount": "5",
+    "id": "9"
+  },
+  {
+    "name": "Cooking Oil",
+    "brand": "Crisco",
+    "stock": "700",
+    "batch": "2020-0010",
+    "expiration": "2023-04-30",
+    "discount": "0",
+    "id": "10"
+  },
+  {
+    "name": "Frozen Vegetables",
+    "brand": "Green Giant",
+    "stock": "825",
+    "batch": "2021-0011",
+    "expiration": "2022-12-31",
+    "discount": "10",
+    "id": "11"
+  },
+  {
+    "name": "Toothpaste",
+    "brand": "Colgate",
+    "stock": "950",
+    "batch": "2020-0012",
+    "expiration": "2024-11-30",
+    "discount": "0",
+    "id": "12"
+  },
+  {
+    "name": "Shampoo",
+    "brand": "Pantene",
+    "stock": "675",
+    "batch": "2021-0013",
+    "expiration": "2023-10-31",
+    "discount": "15",
+    "id": "13"
+  },
+  {
+    "name": "Conditioner",
+    "brand": "Tresemme",
+    "stock": "550",
+    "batch": "2020-0014",
+    "expiration": "2022-08-31",
+    "discount": "0",
+    "id": "14"
+  },
+  {
+    "name": "Deodorant",
+    "brand": "Dove",
+    "stock": "875",
+    "batch": "2021-0015",
+    "expiration": "2024-07-31",
+    "discount": "10",
+    "id": "15"
+  },
+  {
+    "name": "Toothbrush",
+    "brand": "Oral-B",
+    "stock": "925",
+    "batch": "2020-0016",
+    "expiration": "2023-09-30",
+    "discount": "0",
+    "id": "16"
+  },
+  {
+    "name": "Mouthwash",
+    "brand": "Listerine",
+    "stock": "650",
+    "batch": "2021-0017",
+    "expiration": "2022-05-31",
+    "discount": "5",
+    "id": "17"
+  },
+  {
+    "name": "Feminine Pads",
+    "brand": "Always",
+    "stock": "800",
+    "batch": "2020-0018",
+    "expiration": "2024-04-30",
+    "discount": "0",
+    "id": "18"
+  },
+  {
+    "name": "Shaving Cream",
+    "brand": "Gillette",
+    "stock": "575",
+    "batch": "2021-0019",
+    "expiration": "2023-03-31",
+    "discount": "10",
+    "id": "19"
+  },
+  {
+    "name": "Razors",
+    "brand": "Schick",
+    "stock": "925",
+    "batch": "2020-0020",
+    "expiration": "2022-12-31",
+    "discount": "0",
+    "id": "20"
+  },
+  {
+    "name": "Baby Diapers",
+    "brand": "Pampers",
+    "stock": "700",
+    "batch": "2021-0021",
+    "expiration": "2024-11-30",
+    "discount": "15",
+    "id": "21"
+  },
+  {
+    "name": "Baby Wipes",
+    "brand": "Huggies",
+    "stock": "550",
+    "batch": "2020-0022",
+    "expiration": "2023-10-31",
+    "discount": "0",
+    "id": "22"
+  },
+  {
+    "name": "Pet Food",
+    "brand": "Purina",
+    "stock": "875",
+    "batch": "2021-0023",
+    "expiration": "2022-08-31",
+    "discount": "10",
+    "id": "23"
+  },
+  {
+    "name": "Cat Litter",
+    "brand": "Tidy Cats",
+    "stock": "925",
+    "batch": "2020-0024",
+    "expiration": "2024-07-31",
+    "discount": "0",
+    "id": "24"
+  },
+  {
+    "name": "Dog Treats",
+    "brand": "Milk-Bone",
+    "stock": "650",
+    "batch": "2021-0025",
+    "expiration": "2023-06-30",
+    "discount": "5",
+    "id": "25"
+  },
+  {
+    "name": "Bottled Water",
+    "brand": "Dasani",
+    "stock": "800",
+    "batch": "2020-0026",
+    "expiration": "2025-05-31",
+    "discount": "0",
+    "id": "26"
+  },
+  {
+    "name": "Soft Drinks",
+    "brand": "Coca-Cola",
+    "stock": "575",
+    "batch": "2021-0027",
+    "expiration": "2023-04-30",
+    "discount": "10",
+    "id": "27"
+  },
+  {
+    "name": "Snack Bars",
+    "brand": "Nature Valley",
+    "stock": "925",
+    "batch": "2020-0028",
+    "expiration": "2022-12-31",
+    "discount": "0",
+    "id": "28"
+  },
+  {
+    "name": "Cookies",
+    "brand": "Oreo",
+    "stock": "700",
+    "batch": "2021-0029",
+    "expiration": "2024-11-30",
+    "discount": "15",
+    "id": "29"
+  },
+  {
+    "name": "Chips",
+    "brand": "Lays",
+    "stock": "550",
+    "batch": "2020-0030",
+    "expiration": "2023-10-31",
+    "discount": "0",
+    "id": "30"
+  },
+  {
+    "name": "Chocolate",
+    "brand": "Hershey's",
+    "stock": "875",
+    "batch": "2021-0031",
+    "expiration": "2022-08-31",
+    "discount": "10",
+    "id": "31"
+  },
+  {
+    "name": "Ice Cream",
+    "brand": "Ben & Jerry's",
+    "stock": "925",
+    "batch": "2020-0032",
+    "expiration": "2024-07-31",
+    "discount": "0",
+    "id": "32"
+  },
+  {
+    "name": "Frozen Dinners",
+    "brand": "Lean Cuisine",
+    "stock": "650",
+    "batch": "2021-0033",
+    "expiration": "2023-06-30",
+    "discount": "5",
+    "id": "33"
+  },
+  {
+    "name": "Bread",
+    "brand": "Wonder",
+    "stock": "800",
+    "batch": "2020-0034",
+    "expiration": "2025-05-31",
+    "discount": "0",
+    "id": "34"
+  },
+  {
+    "name": "Eggs",
+    "brand": "Eggland's Best",
+    "stock": "575",
+    "batch": "2021-0035",
+    "expiration": "2023-04-30",
+    "discount": "10",
+    "id": "35"
+  },
+  {
+    "name": "Milk",
+    "brand": "Tropicana",
+    "stock": "925",
+    "batch": "2020-0036",
+    "expiration": "2022-12-31",
+    "discount": "0",
+    "id": "36"
+  },
+  {
+    "name": "Cheese",
+    "brand": "Kraft",
+    "stock": "700",
+    "batch": "2021-0037",
+    "expiration": "2024-11-30",
+    "discount": "15",
+    "id": "37"
+  },
+  {
+    "name": "Yogurt",
+    "brand": "Chobani",
+    "stock": "550",
+    "batch": "2020-0038",
+    "expiration": "2023-10-31",
+    "discount": "0",
+    "id": "38"
+  },
+  {
+    "name": "Fresh Produce",
+    "brand": "Dole",
+    "stock": "875",
+    "batch": "2021-0039",
+    "expiration": "2022-08-31",
+    "discount": "10",
+    "id": "39"
+  },
+  {
+    "name": "Meat",
+    "brand": "Tyson",
+    "stock": "925",
+    "batch": "2020-0040",
+    "expiration": "2024-07-31",
+    "discount": "0",
+    "id": "40"
+  },
+  {
+    "name": "Fish",
+    "brand": "Gorton's",
+    "stock": "650",
+    "batch": "2021-0041",
+    "expiration": "2023-06-30",
+    "discount": "5",
+    "id": "41"
+  },
+  {
+    "name": "Poultry",
+    "brand": "Perdue",
+    "stock": "800",
+    "batch": "2020-0042",
+    "expiration": "2025-05-31",
+    "discount": "0",
+    "id": "42"
+  },
+  {
+    "name": "Canned Vegetables",
+    "brand": "Del Monte",
+    "stock": "575",
+    "batch": "2021-0043",
+    "expiration": "2023-04-30",
+    "discount": "10",
+    "id": "43"
+  },
+  {
+    "name": "Sauces",
+    "brand": "Heinz",
+    "stock": "925",
+    "batch": "2020-0044",
+    "expiration": "2022-12-31",
+    "discount": "0",
+    "id": "44"
+  },
+  {
+    "name": "Spices",
+    "brand": "McCormick",
+    "stock": "700",
+    "batch": "2021-0045",
+    "expiration": "2024-11-30",
+    "discount": "15",
+    "id": "45"
+  },
+  {
+    "name": "Baking Supplies",
+    "brand": "Nestle",
+    "stock": "550",
+    "batch": "2020-0046",
+    "expiration": "2023-10-31",
+    "discount": "0",
+    "id": "46"
+  },
+  {
+    "name": "Candy",
+    "brand": "M&M's",
+    "stock": "875",
+    "batch": "2021-0047",
+    "expiration": "2022-08-31",
+    "discount": "10",
+    "id": "47"
+  },
+  {
+    "name": "Baby Formula",
+    "brand": "Similac",
+    "stock": "925",
+    "batch": "2020-0048",
+    "expiration": "2024-07-31",
+    "discount": "0",
+    "id": "48"
+  },
+  {
+    "name": "Cleaning Supplies",
+    "brand": "Lysol",
+    "stock": "650",
+    "batch": "2021-0049",
+    "expiration": "2023-06-30",
+    "discount": "5",
+    "id": "49"
+  },
+  {
+    "name": "Personal Care",
+    "brand": "Dove",
+    "stock": "800",
+    "batch": "2020-0050",
+    "expiration": "2025-05-31",
+    "discount": "0",
+    "id": "50"
+  }
+]

--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const dataPath = path.join(__dirname, '../assets/data.json');
+
+interface Product {
+  name: string;
+  brand: string;
+  stock: string;
+  batch: string;
+  expiration: string;
+  discount: string;
+  id: string;
+}
+
+const readProducts = (): Product[] => {
+  const data = fs.readFileSync(dataPath, 'utf8');
+  return JSON.parse(data);
+};
+
+const writeProducts = (products: Product[]): void => {
+  fs.writeFileSync(dataPath, JSON.stringify(products, null, 2), 'utf8');
+};
+
+export const createProduct = (req: Request, res: Response): void => {
+  const products = readProducts();
+  const newProduct: Product = { ...req.body, id: (products.length + 1).toString() };
+  products.push(newProduct);
+  writeProducts(products);
+  res.status(201).json(newProduct);
+};
+
+export const getAllProducts = (req: Request, res: Response): void => {
+  const products = readProducts();
+  res.json(products);
+};
+
+export const getProductById = (req: Request, res: Response): Response<any, Record<string, any>> => {
+  const products = readProducts();
+  const product = products.find(p => p.id === req.params.id);
+  if (!product) {
+    return res.status(404).json({ error: 'Product not found' });
+  }
+  return res.json(product);
+};
+
+export const updateProductById = (req: Request, res: Response): Response<any, Record<string, any>> => {
+  const products = readProducts();
+  const index = products.findIndex(p => p.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Product not found' });
+  }
+  products[index] = { ...products[index], ...req.body };
+  writeProducts(products);
+  return res.json(products[index]);
+};
+
+export const patchProductById = (req: Request, res: Response): Response<any, Record<string, any>> => {
+  const products = readProducts();
+  const index = products.findIndex(p => p.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Product not found' });
+  }
+  products[index] = { ...products[index], ...req.body };
+  writeProducts(products);
+  return res.json(products[index]);
+};
+
+export const deleteProductById = (req: Request, res: Response): Response<any, Record<string, any>> => {
+  let products = readProducts();
+  const index = products.findIndex(p => p.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Product not found' });
+  }
+  products = products.filter(p => p.id !== req.params.id);
+  writeProducts(products);
+  return res.status(204).send();
+};
+
+export const queryProducts = (req: Request, res: Response): void => {
+  const products = readProducts();
+  const { brand, stockover, stockbelow, discountover, discountbelow, expireover, expirebelow } = req.query;
+
+  let result = products;
+
+  if (brand) {
+    result = result.filter(p => p.brand.toLowerCase() === (brand as string).toLowerCase());
+  }
+  if (stockover) {
+    result = result.filter(p => parseInt(p.stock) >= parseInt(stockover as string));
+  }
+  if (stockbelow) {
+    result = result.filter(p => parseInt(p.stock) <= parseInt(stockbelow as string));
+  }
+  if (discountover) {
+    result = result.filter(p => parseInt(p.discount) >= parseInt(discountover as string));
+  }
+  if (discountbelow) {
+    result = result.filter(p => parseInt(p.discount) <= parseInt(discountbelow as string));
+  }
+  if (expireover) {
+    result = result.filter(p => new Date(p.expiration) >= new Date(expireover as string));
+  }
+  if (expirebelow) {
+    result = result.filter(p => new Date(p.expiration) <= new Date(expirebelow as string));
+  }
+
+  res.json(result);
+};

--- a/src/routes/productRoute.ts
+++ b/src/routes/productRoute.ts
@@ -1,0 +1,20 @@
+import express, { Request, Response } from 'express';
+const productRoute = express.Router();
+import {
+  createProduct,
+  getAllProducts,
+  getProductById,
+  updateProductById,
+  patchProductById,
+  deleteProductById,
+  queryProducts
+} from '@/controllers/productController';
+
+productRoute.post('/', createProduct);
+productRoute.get('/', queryProducts);
+productRoute.get('/:id', getProductById);
+productRoute.put('/:id', updateProductById);
+productRoute.patch('/:id', patchProductById);
+productRoute.delete('/:id', deleteProductById);
+
+export default productRoute;


### PR DESCRIPTION
- Implementadas operaciones CRUD para productos:
  - POST /products: Añadir un nuevo producto.
  - GET /products: Obtener todos los productos, soporta parámetros de consulta para filtrado.
  - GET /products/:id: Obtener un producto por su ID.
  - PUT /products/:id: Actualizar un producto por su ID.
  - PATCH /products/:id: Actualizar parcialmente un producto por su ID.
  - DELETE /products/:id: Eliminar un producto por su ID.

- Parámetros de consulta soportados para GET /products:
  - brand: Filtrar productos por marca.
  - stockover: Obtener productos con stock mayor o igual al valor dado.
  - stockbelow: Obtener productos con stock menor o igual al valor dado.
  - discountover: Obtener productos con descuento mayor o igual al valor dado.
  - discountbelow: Obtener productos con descuento menor o igual al valor dado.
  - expireover: Obtener productos con fecha de expiración mayor o igual a la fecha dada.
  - expirebelow: Obtener productos con fecha de expiración menor o igual a la fecha dada.